### PR TITLE
Fixed Trigonometry Values fav button - Issue #96

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,8 +297,8 @@
                                 </a>
                         </td>
                         <td style="float:right;border-top: none;">
-                            <span onclick="addtofavourite('Trigonometry Values','#trigonovaluestable','c','strigoimgfav')"><img
-                                    id="strigoimgfav" src="images/unfavourite.png" style="height:25px;"></span>
+                            <span onclick="addtofavourite('Trigonometry Values','#trigonovaluestable','c','trigovaluesimgfav')"><img
+                                    id="trigovaluesimgfav" src="images/unfavourite.png" style="height:25px;"></span>
                         </td>
                     </tr>
                 </table>


### PR DESCRIPTION
## Related Issuse

- Upon clicking the Trigonometry Values button, the P/B/H favorite button gets activated instead of the Trigonometry Values option. Although it shows up in the footer, it doesn't seem to activate the "heart"/favorite button.

Closes: #96 

#### Describe the changes you've made

Changed the name of the id passed to the addFavorite function from "strigoimgfav" to "trigovaluesimgfav" to fix the problem.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| ![ss1](https://user-images.githubusercontent.com/49470807/110907910-16dc3380-8334-11eb-84d7-a984a6c02a15.png)| ![ss2](https://user-images.githubusercontent.com/49470807/110907928-19d72400-8334-11eb-8c18-98926c839473.PNG)|
